### PR TITLE
fix minor inconsistency in example configuration

### DIFF
--- a/documentation/repositories.html.haml
+++ b/documentation/repositories.html.haml
@@ -50,7 +50,7 @@ layout: base
     # The feature 'FEATURE_ONE' is disabled
     FEATURE_ONE=false
     
-    # The feature 'FEATURE_TWO' is enabled for the users 'chkal' and 'joe'
+    # The feature 'FEATURE_TWO' is enabled for the users 'chkal' and 'john'
     FEATURE_TWO=true
     FEATURE_TWO.strategy = username
     FEATURE_TWO.param.users = chkal, john


### PR DESCRIPTION
former inconsistency: description said "users 'chkal' and 'joe'" while config said "users = chkal, John"
now: set both to "john"