### PR TITLE
Added a statement in the Java example for spring-boot-starter

### DIFF
--- a/documentation/spring-boot-starter.html.haml
+++ b/documentation/spring-boot-starter.html.haml
@@ -82,7 +82,8 @@ layout: base
     @Controller
     public class MyClass {
       private FeatureManager manager;
-
+      public static final Feature HELLO_WORLD = new NamedFeature("HELLO_WORLD");
+      
       public MyClass(FeatureManager manager) {
           this.manager = manager;
       }


### PR DESCRIPTION
Without this statement, it was not clear to me how the `HELLO_WORLD` feature was being referenced later in the code snippet. 