### PR TITLE
the repository is togglz-junit

### DIFF
--- a/documentation/testing.html.haml
+++ b/documentation/testing.html.haml
@@ -168,7 +168,7 @@ layout: base
     <!-- Togglz testing support -->
     <dependency>
       <groupId>org.togglz</groupId>
-      <artifactId>togglz-junit5</artifactId>
+      <artifactId>togglz-junit</artifactId>
       <version>#{site.stableVersion}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
There's no 3.1.1 here: https://mvnrepository.com/artifact/org.togglz/togglz-junit5
But here: https://mvnrepository.com/artifact/org.togglz/togglz-junit